### PR TITLE
case problem, using browserify I get errors when case is wrong

### DIFF
--- a/difference.js
+++ b/difference.js
@@ -20,7 +20,7 @@ module.exports = function(tileLayers, tile, done) {
   tigerRoads = normalize(flatten(tigerRoads));
 
   // buffer streets
-  var streetBuffers = turf.featurecollection([]);
+  var streetBuffers = turf.featureCollection([]);
   streetBuffers.features = osmData.features.map(function(f){
     if (f.properties.highway) {
       return turf.buffer(road, 20, 'meters').features[0];


### PR DESCRIPTION
A possible other bug is also turf.merge (using this code as-is, the object does't have that method present.  But this might be due to not all turf packages being exported.

